### PR TITLE
include root as event-param for PacketVerifiedAndSealed emitted

### DIFF
--- a/contracts/socket/SocketSrc.sol
+++ b/contracts/socket/SocketSrc.sol
@@ -14,11 +14,13 @@ abstract contract SocketSrc is SocketBase {
      * @notice emits the verification and seal confirmation of a packet
      * @param transmitter address of transmitter recovered from sig
      * @param packetId packed id
+     * @param root root
      * @param signature signature of attester
      */
     event PacketVerifiedAndSealed(
         address indexed transmitter,
         uint256 indexed packetId,
+        bytes32 root,
         bytes signature
     );
 
@@ -129,6 +131,6 @@ abstract contract SocketSrc is SocketBase {
 
         if (!isTransmitter) revert InvalidAttester();
 
-        emit PacketVerifiedAndSealed(transmitter, packetId, signature_);
+        emit PacketVerifiedAndSealed(transmitter, packetId, root, signature_);
     }
 }

--- a/test/IntegrationTest.t.sol
+++ b/test/IntegrationTest.t.sol
@@ -16,6 +16,12 @@ contract HappyTest is Setup {
     event ExecutionSuccess(uint256 msgId);
     event ExecutionFailed(uint256 msgId, string result);
     event ExecutionFailedBytes(uint256 msgId, bytes result);
+    event PacketVerifiedAndSealed(
+        address indexed transmitter,
+        uint256 indexed packetId,
+        bytes32 root,
+        bytes signature
+    );
 
     function setUp() external {
         uint256[] memory transmitterPivateKeys = new uint256[](1);
@@ -194,6 +200,8 @@ contract HappyTest is Setup {
             bytes memory sig_
         ) = _getLatestSignature(_a, capacitor, _b.chainSlug);
 
+        vm.expectEmit(false, false, false, true);
+        emit PacketVerifiedAndSealed(_transmitter, packetId_, root_, sig_);
         _sealOnSrc(_a, capacitor, sig_);
         _proposeOnDst(_b, sig_, packetId_, root_);
 


### PR DESCRIPTION
feat: include root as event-param for PacketVerifiedAndSealed emitted during seal function call on SocketSrc