### PR TITLE
native-relay functions and Interface for Batcher

### DIFF
--- a/contracts/interfaces/INativeRelay.sol
+++ b/contracts/interfaces/INativeRelay.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.7;
+
+interface INativeRelay {
+    /**
+     * @notice receiveMessage on PolygonRootReceiver
+     * @param receivePacketProof receivePacketProof
+     */
+    function receiveMessage(bytes memory receivePacketProof) external;
+
+    function initiateNativeConfirmation(
+        bytes32 packetId,
+        uint256 maxSubmissionCost,
+        uint256 maxGas,
+        uint256 gasPriceBid
+    ) external;
+
+    function initiateNativeConfirmation(bytes32 packetId) external;
+}


### PR DESCRIPTION
# Native Relay batching

## initiateNativeConfirmation
- `initiateNativeConfirmation` is to be called on Arbitrum and other native chains from offchain Relayers
- this is done per packet relay
- now batching is added to be able to initiate `initiateNativeConfirmation` for a chunk of packets

new functions created:

```
    function initiateArbitrumNativeBatch(
        address switchboardAddress_,
        ArbitrumNativeInitiatorRequest[]
            calldata arbitrumNativeInitiatorRequests_
    ) external
```

```
    function initiateNativeBatch(
        address switchboardAddress_,
        bytes32[] calldata nativePacketIds_
    ) external
```


## receiveMessage on PolygonRootReeceiver
- offchain relayer (attester) calls `receiveMessage` function on `PolygonRootReceiver` contract
- this is done on transaction per packet
- this can be batched via SocketBatcher

new function created:  

```
    function receiveMessageBatch(
        address polygonRootReceiverAddress_,
        bytes[] calldata receivePacketProofs_
    ) external

```




