### PR TITLE
fix: use memory instead of storage

### DIFF
--- a/contracts/socket/SocketSrc.sol
+++ b/contracts/socket/SocketSrc.sol
@@ -37,7 +37,7 @@ abstract contract SocketSrc is SocketBase {
         uint256 msgGasLimit_,
         bytes calldata payload_
     ) external payable override returns (bytes32 msgId) {
-        PlugConfig storage plugConfig = _plugConfigs[msg.sender][
+        PlugConfig memory plugConfig = _plugConfigs[msg.sender][
             remoteChainSlug_
         ];
         uint32 localChainSlug = chainSlug;

--- a/contracts/socket/SocketSrc.sol
+++ b/contracts/socket/SocketSrc.sol
@@ -62,6 +62,11 @@ abstract contract SocketSrc is SocketBase {
         );
 
         plugConfig.capacitor__.addPackedMessage(packedMessage);
+
+        // call to unknown external contract at the end
+        plugConfig.outboundSwitchboard__.payFees{value: fees.switchboardFees}(
+            remoteChainSlug_
+        );
         emit MessageOutbound(
             localChainSlug,
             msg.sender,
@@ -106,9 +111,6 @@ abstract contract SocketSrc is SocketBase {
                 fees.switchboardFees;
 
             transmitManager__.payFees{value: fees.transmissionFees}(
-                remoteChainSlug_
-            );
-            switchboard__.payFees{value: fees.switchboardFees}(
                 remoteChainSlug_
             );
             executionManager__.payFees{value: fees.executionFee}(


### PR DESCRIPTION
As initially plug config was being taken from storage, it was possible to reenter and connect new switchboard in between outbound. This could lead to low fees being collected in switchboards. Using memory, caches the config and do not allow anyone to reenter and change it in same config.