### PR TITLE
Fix fast switchboard fees

### DIFF
--- a/contracts/switchboard/default-switchboards/OptimisticSwitchboard.sol
+++ b/contracts/switchboard/default-switchboards/OptimisticSwitchboard.sol
@@ -61,7 +61,7 @@ contract OptimisticSwitchboard is SwitchboardBase {
     function setFees(
         uint256 nonce_,
         uint32 dstChainSlug_,
-        uint128,
+        uint128 switchboardFees_,
         uint128 verificationFees_,
         bytes calldata signature_
     ) external override {
@@ -73,7 +73,7 @@ contract OptimisticSwitchboard is SwitchboardBase {
                     chainSlug,
                     dstChainSlug_,
                     nonce_,
-                    0,
+                    switchboardFees_,
                     verificationFees_
                 )
             ),
@@ -86,7 +86,10 @@ contract OptimisticSwitchboard is SwitchboardBase {
             if (nonce_ != nextNonce[feesUpdater]++) revert InvalidNonce();
         }
 
-        fees[dstChainSlug_].verificationFees = verificationFees_;
-        emit SwitchboardFeesSet(dstChainSlug_, fees[dstChainSlug_]);
+        Fees storage fee = fees[dstChainSlug_];
+        fee.verificationFees = verificationFees_;
+        fee.switchboardFees = switchboardFees_;
+
+        emit SwitchboardFeesSet(dstChainSlug_, fee);
     }
 }

--- a/contracts/switchboard/default-switchboards/SwitchboardBase.sol
+++ b/contracts/switchboard/default-switchboards/SwitchboardBase.sol
@@ -308,45 +308,6 @@ abstract contract SwitchboardBase is ISwitchboard, AccessControlExtended {
     }
 
     /**
-     * @inheritdoc ISwitchboard
-     */
-    function setFees(
-        uint256 nonce_,
-        uint32 dstChainSlug_,
-        uint128 switchboardFees_,
-        uint128 verificationFees_,
-        bytes calldata signature_
-    ) external override {
-        address feesUpdater = signatureVerifier__.recoverSigner(
-            keccak256(
-                abi.encode(
-                    FEES_UPDATE_SIG_IDENTIFIER,
-                    address(this),
-                    chainSlug,
-                    dstChainSlug_,
-                    nonce_,
-                    switchboardFees_,
-                    verificationFees_
-                )
-            ),
-            signature_
-        );
-
-        _checkRoleWithSlug(FEES_UPDATER_ROLE, dstChainSlug_, feesUpdater);
-        // Nonce is used by gated roles and we don't expect nonce to reach the max value of uint256
-        unchecked {
-            if (nonce_ != nextNonce[feesUpdater]++) revert InvalidNonce();
-        }
-        Fees memory feesObject = Fees({
-            switchboardFees: switchboardFees_,
-            verificationFees: verificationFees_
-        });
-
-        fees[dstChainSlug_] = feesObject;
-        emit SwitchboardFeesSet(dstChainSlug_, feesObject);
-    }
-
-    /**
      * @notice Withdraw fees from the contract to an account.
      * @param account_ The address where we should send the fees.
      */

--- a/test/switchboard/default-switchboards/OptimisticSwitchboard.t.sol
+++ b/test/switchboard/default-switchboards/OptimisticSwitchboard.t.sol
@@ -132,7 +132,7 @@ contract OptimisticSwitchboardTest is Setup {
         vm.stopPrank();
     }
 
-    function testregisterSiblingSlug() public {
+    function testRegisterSiblingSlug() public {
         hoax(_raju);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -167,12 +167,11 @@ contract OptimisticSwitchboardTest is Setup {
         );
 
         assertEq(optimisticSwitchboard.initialPacketCount(_b.chainSlug), 1);
-
         vm.stopPrank();
     }
 
     function testSetFees() external {
-        uint128 switchboardFee = 1000;
+        uint128 switchboardFee = 0;
         uint128 verificationFee = 1000;
         uint256 feeNonce = optimisticSwitchboard.nextNonce(_socketOwner);
 

--- a/test/switchboard/default-switchboards/OptimisticSwitchboard.t.sol
+++ b/test/switchboard/default-switchboards/OptimisticSwitchboard.t.sol
@@ -171,7 +171,7 @@ contract OptimisticSwitchboardTest is Setup {
     }
 
     function testSetFees() external {
-        uint128 switchboardFee = 0;
+        uint128 switchboardFee = 1000;
         uint128 verificationFee = 1000;
         uint256 feeNonce = optimisticSwitchboard.nextNonce(_socketOwner);
 


### PR DESCRIPTION
Switchboard fees for fast switchboard should cover the attestation cost for all watchers. Hence fixed this in contract by:
- multiplying fees with total watchers in `setFees`
- adjusted the fees in grantWatcherRole and revokeWatcherRole