### PR TITLE
Fix/attest signature

### DIFF
--- a/contracts/switchboard/default-switchboards/FastSwitchboard.sol
+++ b/contracts/switchboard/default-switchboards/FastSwitchboard.sol
@@ -107,7 +107,13 @@ contract FastSwitchboard is SwitchboardBase {
 
         address watcher = signatureVerifier__.recoverSigner(
             keccak256(
-                abi.encode(address(this), chainSlug, packetId_, proposalCount_, root_)
+                abi.encode(
+                    address(this),
+                    chainSlug,
+                    packetId_,
+                    proposalCount_,
+                    root_
+                )
             ),
             signature_
         );

--- a/contracts/switchboard/default-switchboards/FastSwitchboard.sol
+++ b/contracts/switchboard/default-switchboards/FastSwitchboard.sol
@@ -107,7 +107,7 @@ contract FastSwitchboard is SwitchboardBase {
 
         address watcher = signatureVerifier__.recoverSigner(
             keccak256(
-                abi.encode(address(this), chainSlug, packetId_, proposalCount_)
+                abi.encode(address(this), chainSlug, packetId_, proposalCount_, root_)
             ),
             signature_
         );

--- a/test/Setup.t.sol
+++ b/test/Setup.t.sol
@@ -760,7 +760,7 @@ contract Setup is Test {
         uint256 watcherPrivateKey_
     ) internal {
         bytes32 digest = keccak256(
-            abi.encode(switchboardAddress, dstSlug, packetId_, proposalCount_)
+            abi.encode(switchboardAddress, dstSlug, packetId_, proposalCount_, root_)
         );
 
         // generate attest-signature

--- a/test/Setup.t.sol
+++ b/test/Setup.t.sol
@@ -760,7 +760,13 @@ contract Setup is Test {
         uint256 watcherPrivateKey_
     ) internal {
         bytes32 digest = keccak256(
-            abi.encode(switchboardAddress, dstSlug, packetId_, proposalCount_, root_)
+            abi.encode(
+                switchboardAddress,
+                dstSlug,
+                packetId_,
+                proposalCount_,
+                root_
+            )
         );
 
         // generate attest-signature


### PR DESCRIPTION
Adding root as one of the parameters in the attest signature for fast switchboards. 