### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -24,7 +24,7 @@ jobs:
         run: forge install
 
       - name: Set Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 


### PR DESCRIPTION
Maintenance update: switch all jobs to setup-node@v4 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v4.0.0 release](https://github.com/actions/setup-node/releases/tag/v4.0.0).